### PR TITLE
digitizer styleconverter changed ordering in getFontStyleString function

### DIFF
--- a/styleConverter.js
+++ b/styleConverter.js
@@ -50,7 +50,7 @@
            var fontSize = style.fontSize ? style.fontSize+"px" : "";
            var fontWeight = style.fontWeight || "";
 
-           var str = [fontSize,fontWeight,fontFamily].join(" ");
+           var str = [fontWeight,fontSize,fontFamily].join(" ");
            return str;
         };
         if (ol2Style.strokeColor || (typeof ol2Style.strokeOpacity !== 'undefined')) {


### PR DESCRIPTION
* refers to ticket https://github.com/mapbender/mapbender/issues/1308

Changed ordering of the return value in function: getFontStyleString
var str = [fontWeight,fontSize,fontFamily].join(" ");
* definition is weight sizepx fontfamily
* see https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/font
* see f.e. https://openlayers.org/en/latest/examples/vector-labels.html